### PR TITLE
[BNT-2] Dashboard UI — live status, feed, and bounty board

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi>=0.111.0
 uvicorn>=0.29.0
+aiofiles>=23.0

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from typing import Optional, Any
 
 from fastapi import FastAPI, BackgroundTasks
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 DB_PATH = "bounty.db"
@@ -185,3 +186,6 @@ def status():
             entry["payload"] = json.loads(entry["payload"])
         result.append(entry)
     return result
+
+
+app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/server.py
+++ b/server.py
@@ -188,4 +188,14 @@ def status():
     return result
 
 
+@app.get("/api/verdicts")
+def get_verdicts():
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT id, project, role, model, points, reason, created_at FROM verdicts ORDER BY id DESC LIMIT 50"
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
 app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/static/index.html
+++ b/static/index.html
@@ -539,24 +539,16 @@
   }
 
   // ── Render verdicts ──
-  function renderVerdicts(feed) {
-    // We don't have a dedicated /api/verdicts endpoint; derive from feed where event_type indicates a verdict,
-    // or fetch /api/board which has aggregated data. For individual verdicts, use feed items of type 'verdict'.
-    // Show verdict-type feed events, falling back to empty state if none.
-    const verdictItems = feed.filter(f => {
-      const k = (f.event_type || '').toLowerCase();
-      return k.includes('verdict') || k.includes('judge') || k.includes('score');
-    });
-
+  function renderVerdicts(verdicts) {
     const list = document.getElementById('verdict-list');
-    if (!verdictItems.length) {
+    if (!verdicts.length) {
       list.innerHTML = '<div class="empty-state">No verdicts yet</div>';
       return;
     }
-    list.innerHTML = verdictItems.map(item => {
+    list.innerHTML = verdicts.map(item => {
       const role = (item.role || '').charAt(0).toUpperCase() + (item.role || '').slice(1);
-      const pts = item.payload && item.payload.points != null ? item.payload.points : null;
-      const reason = item.payload && item.payload.reason ? item.payload.reason : null;
+      const pts = item.points != null ? item.points : null;
+      const reason = item.reason || null;
       const ptsClass = pts == null ? 'zero' : pts > 0 ? 'pos' : pts < 0 ? 'neg' : 'zero';
       const ptsLabel = pts == null ? '?' : (pts >= 0 ? '+' + pts : pts) + ' pts';
       return `
@@ -575,18 +567,20 @@
   // ── Fetch all data ──
   async function fetchAll() {
     try {
-      const [boardRes, feedRes, statusRes] = await Promise.all([
+      const [boardRes, feedRes, statusRes, verdictsRes] = await Promise.all([
         fetch('/api/board'),
         fetch('/api/feed'),
         fetch('/api/status'),
+        fetch('/api/verdicts'),
       ]);
 
-      if (!boardRes.ok || !feedRes.ok || !statusRes.ok) return;
+      if (!boardRes.ok || !feedRes.ok || !statusRes.ok || !verdictsRes.ok) return;
 
-      const [board, feed, status] = await Promise.all([
+      const [board, feed, status, verdicts] = await Promise.all([
         boardRes.json(),
         feedRes.json(),
         statusRes.json(),
+        verdictsRes.json(),
       ]);
 
       // Update agent status map
@@ -598,7 +592,7 @@
       renderBoard(board);
       renderAgents();
       renderFeed(feed);
-      renderVerdicts(feed);
+      renderVerdicts(verdicts);
 
       document.getElementById('last-update').textContent = 'Updated ' + timeAgo(new Date().toISOString());
     } catch (e) {

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,629 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bounty Monitor</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0d0f14;
+      --surface: #161a22;
+      --surface2: #1e2330;
+      --border: #2a2f3d;
+      --text: #e2e8f0;
+      --muted: #6b7590;
+      --accent: #6366f1;
+      --accent2: #22d3ee;
+      --green: #34d399;
+      --yellow: #fbbf24;
+      --red: #f87171;
+      --idle: #6b7590;
+      --busy: #6366f1;
+      --rework: #f59e0b;
+    }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: 16px 24px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    header h1 {
+      font-size: 1.2rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--text);
+    }
+
+    header h1 span { color: var(--accent); }
+
+    #refresh-indicator {
+      font-size: 0.75rem;
+      color: var(--muted);
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: var(--green);
+      animation: pulse 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.3; }
+    }
+
+    main {
+      flex: 1;
+      padding: 24px;
+      display: grid;
+      grid-template-columns: 1fr 340px;
+      grid-template-rows: auto 1fr;
+      gap: 20px;
+      max-width: 1400px;
+      width: 100%;
+      margin: 0 auto;
+    }
+
+    /* ── Section titles ── */
+    .section-title {
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 12px;
+    }
+
+    /* ── Agent cards ── */
+    #agents-section { grid-column: 1; grid-row: 1; }
+
+    .agent-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 12px;
+    }
+
+    .agent-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 16px;
+      transition: border-color 0.2s;
+    }
+
+    .agent-card.busy { border-color: var(--busy); }
+    .agent-card.rework { border-color: var(--rework); }
+
+    .agent-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 10px;
+    }
+
+    .agent-role {
+      font-size: 0.85rem;
+      font-weight: 600;
+    }
+
+    .status-badge {
+      font-size: 0.65rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      padding: 2px 7px;
+      border-radius: 4px;
+    }
+
+    .status-badge.idle  { background: #1f2435; color: var(--muted); }
+    .status-badge.busy  { background: #22254a; color: #818cf8; }
+    .status-badge.rework { background: #2d1f0e; color: var(--yellow); }
+
+    .agent-task {
+      font-size: 0.75rem;
+      color: var(--muted);
+      margin-bottom: 10px;
+      min-height: 32px;
+      line-height: 1.4;
+      word-break: break-word;
+    }
+
+    .agent-bounty {
+      font-size: 0.75rem;
+      color: var(--accent2);
+      font-weight: 600;
+    }
+
+    /* ── Board section ── */
+    #board-section { grid-column: 2; grid-row: 1 / 3; }
+
+    .board-tabs {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 12px;
+    }
+
+    .tab-btn {
+      flex: 1;
+      padding: 5px 0;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: transparent;
+      color: var(--muted);
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+
+    .tab-btn.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+
+    .board-panel { display: none; }
+    .board-panel.active { display: block; }
+
+    .board-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.78rem;
+    }
+
+    .board-table th {
+      text-align: left;
+      padding: 6px 8px;
+      color: var(--muted);
+      font-weight: 600;
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .board-table td {
+      padding: 8px 8px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: middle;
+    }
+
+    .board-table tr:last-child td { border-bottom: none; }
+
+    .pts {
+      font-weight: 700;
+      color: var(--accent2);
+      text-align: right;
+    }
+
+    .rank { color: var(--muted); font-size: 0.7rem; }
+
+    /* ── Feed + verdicts ── */
+    #bottom-section {
+      grid-column: 1;
+      grid-row: 2;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+    }
+
+    .scroll-panel {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .scroll-panel-header {
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .scroll-inner {
+      flex: 1;
+      overflow-y: auto;
+      max-height: 320px;
+      padding: 8px 0;
+    }
+
+    .scroll-inner::-webkit-scrollbar { width: 4px; }
+    .scroll-inner::-webkit-scrollbar-track { background: transparent; }
+    .scroll-inner::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    /* ── Feed items ── */
+    .feed-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 7px 14px;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.77rem;
+      line-height: 1.4;
+    }
+
+    .feed-item:last-child { border-bottom: none; }
+
+    .feed-emoji { font-size: 1rem; flex-shrink: 0; }
+
+    .feed-meta { color: var(--muted); font-size: 0.68rem; }
+
+    .feed-role { color: var(--accent); font-weight: 600; }
+
+    /* ── Verdict items ── */
+    .verdict-item {
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.77rem;
+    }
+
+    .verdict-item:last-child { border-bottom: none; }
+
+    .verdict-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 4px;
+    }
+
+    .verdict-role { color: var(--accent); font-weight: 600; font-size: 0.78rem; }
+
+    .verdict-pts {
+      font-weight: 700;
+      font-size: 0.78rem;
+    }
+
+    .verdict-pts.pos { color: var(--green); }
+    .verdict-pts.neg { color: var(--red); }
+    .verdict-pts.zero { color: var(--muted); }
+
+    .verdict-reason {
+      color: var(--muted);
+      font-size: 0.72rem;
+      line-height: 1.4;
+    }
+
+    .empty-state {
+      padding: 24px 14px;
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-align: center;
+    }
+
+    /* ── Board panels wrapper ── */
+    .board-wrapper {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 16px;
+    }
+
+    @media (max-width: 900px) {
+      main {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto;
+      }
+      #board-section { grid-column: 1; grid-row: 3; }
+      #bottom-section { grid-column: 1; grid-row: 2; grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Bounty <span>Monitor</span></h1>
+  <div id="refresh-indicator">
+    <span class="dot"></span>
+    <span id="last-update">—</span>
+  </div>
+</header>
+
+<main>
+  <!-- Agent cards -->
+  <section id="agents-section">
+    <div class="section-title">Agent Status</div>
+    <div class="agent-grid" id="agent-grid"></div>
+  </section>
+
+  <!-- Leaderboard sidebar -->
+  <section id="board-section">
+    <div class="board-wrapper">
+      <div class="section-title" style="margin-bottom:8px;">Leaderboard</div>
+      <div class="board-tabs">
+        <button class="tab-btn active" data-tab="by-role">By Role</button>
+        <button class="tab-btn" data-tab="by-model">By Model</button>
+      </div>
+      <div id="by-role" class="board-panel active">
+        <table class="board-table">
+          <thead><tr><th>#</th><th>Role</th><th>Verdicts</th><th>Pts</th></tr></thead>
+          <tbody id="board-role-body"></tbody>
+        </table>
+      </div>
+      <div id="by-model" class="board-panel">
+        <table class="board-table">
+          <thead><tr><th>#</th><th>Model</th><th>Verdicts</th><th>Pts</th></tr></thead>
+          <tbody id="board-model-body"></tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- Activity feed + verdicts -->
+  <div id="bottom-section">
+    <div class="scroll-panel">
+      <div class="scroll-panel-header">Activity Feed</div>
+      <div class="scroll-inner" id="feed-list"></div>
+    </div>
+    <div class="scroll-panel">
+      <div class="scroll-panel-header">Judge Verdicts</div>
+      <div class="scroll-inner" id="verdict-list"></div>
+    </div>
+  </div>
+</main>
+
+<script>
+  const ROLES = ['Planner', 'Builder', 'Reviewer', 'Tester', 'Reviser'];
+
+  const ROLE_EMOJI = {
+    planner: '🗺️', builder: '🔨', reviewer: '🔍', tester: '🧪', reviser: '✏️',
+  };
+
+  const EVENT_EMOJI = {
+    start: '▶️', started: '▶️',
+    done: '✅', complete: '✅', finished: '✅',
+    error: '❌', fail: '❌', failed: '❌',
+    rework: '🔄', retry: '🔄',
+    idle: '💤',
+    review: '🔍',
+    test: '🧪',
+    plan: '🗺️',
+    build: '🔨',
+  };
+
+  function eventEmoji(eventType) {
+    const key = (eventType || '').toLowerCase();
+    for (const [k, v] of Object.entries(EVENT_EMOJI)) {
+      if (key.includes(k)) return v;
+    }
+    return '📌';
+  }
+
+  function statusFromEvent(eventType) {
+    const k = (eventType || '').toLowerCase();
+    if (k.includes('rework') || k.includes('retry')) return 'rework';
+    if (k.includes('idle') || k.includes('done') || k.includes('complete') || k.includes('finish')) return 'idle';
+    return 'busy';
+  }
+
+  function timeAgo(isoStr) {
+    if (!isoStr) return '';
+    const diff = Math.floor((Date.now() - new Date(isoStr).getTime()) / 1000);
+    if (diff < 60) return `${diff}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    return `${Math.floor(diff / 3600)}h ago`;
+  }
+
+  function shortModel(model) {
+    if (!model) return '—';
+    return model.replace(/^claude-/, '').replace(/-\d{8}$/, '');
+  }
+
+  // ── State ──
+  let agentScores = {};   // role -> total_points (from board)
+  let agentStatus = {};   // role -> latest event entry
+
+  // ── Render agents ──
+  function renderAgents() {
+    const grid = document.getElementById('agent-grid');
+    grid.innerHTML = '';
+    for (const role of ROLES) {
+      const key = role.toLowerCase();
+      const ev = agentStatus[key] || {};
+      const status = ev.event_type ? statusFromEvent(ev.event_type) : 'idle';
+      const points = agentScores[key] || 0;
+      const task = ev.event_type
+        ? `${eventEmoji(ev.event_type)} ${ev.event_type}${ev.payload && typeof ev.payload === 'object' && ev.payload.task ? ': ' + ev.payload.task : ''}`
+        : 'No activity yet';
+
+      const card = document.createElement('div');
+      card.className = `agent-card ${status}`;
+      card.innerHTML = `
+        <div class="agent-header">
+          <span class="agent-role">${ROLE_EMOJI[key] || '🤖'} ${role}</span>
+          <span class="status-badge ${status}">${status}</span>
+        </div>
+        <div class="agent-task">${escHtml(task)}</div>
+        <div class="agent-bounty">⭐ ${points} pts</div>
+      `;
+      grid.appendChild(card);
+    }
+  }
+
+  // ── Render leaderboard ──
+  function renderBoard(data) {
+    // By role
+    const byRole = {};
+    for (const row of data) {
+      const k = (row.role || '').toLowerCase();
+      if (!byRole[k]) byRole[k] = { role: row.role, pts: 0, verdicts: 0 };
+      byRole[k].pts += row.total_points;
+      byRole[k].verdicts += row.verdict_count;
+    }
+    const roleRows = Object.values(byRole).sort((a, b) => b.pts - a.pts);
+    // Store for agent cards
+    agentScores = {};
+    for (const r of roleRows) agentScores[(r.role || '').toLowerCase()] = r.pts;
+
+    const roleTbody = document.getElementById('board-role-body');
+    roleTbody.innerHTML = roleRows.length ? roleRows.map((r, i) => `
+      <tr>
+        <td class="rank">${i + 1}</td>
+        <td>${escHtml((r.role || '').charAt(0).toUpperCase() + (r.role || '').slice(1))}</td>
+        <td style="color:var(--muted)">${r.verdicts}</td>
+        <td class="pts">${r.pts}</td>
+      </tr>
+    `).join('') : '<tr><td colspan="4" class="empty-state">No data yet</td></tr>';
+
+    // By model
+    const byModel = {};
+    for (const row of data) {
+      const k = row.model || '(unknown)';
+      if (!byModel[k]) byModel[k] = { model: k, pts: 0, verdicts: 0 };
+      byModel[k].pts += row.total_points;
+      byModel[k].verdicts += row.verdict_count;
+    }
+    const modelRows = Object.values(byModel).sort((a, b) => b.pts - a.pts);
+    const modelTbody = document.getElementById('board-model-body');
+    modelTbody.innerHTML = modelRows.length ? modelRows.map((r, i) => `
+      <tr>
+        <td class="rank">${i + 1}</td>
+        <td style="font-size:0.72rem">${escHtml(shortModel(r.model))}</td>
+        <td style="color:var(--muted)">${r.verdicts}</td>
+        <td class="pts">${r.pts}</td>
+      </tr>
+    `).join('') : '<tr><td colspan="4" class="empty-state">No data yet</td></tr>';
+  }
+
+  // ── Render feed ──
+  function renderFeed(items) {
+    const list = document.getElementById('feed-list');
+    if (!items.length) {
+      list.innerHTML = '<div class="empty-state">No activity yet</div>';
+      return;
+    }
+    list.innerHTML = items.map(item => {
+      const emoji = eventEmoji(item.event_type);
+      const role = (item.role || '').charAt(0).toUpperCase() + (item.role || '').slice(1);
+      const when = timeAgo(item.created_at);
+      const detail = item.payload && typeof item.payload === 'object' && item.payload.task
+        ? ` — ${item.payload.task}`
+        : '';
+      return `
+        <div class="feed-item">
+          <span class="feed-emoji">${emoji}</span>
+          <div>
+            <span class="feed-role">${escHtml(role)}</span>
+            <span style="color:var(--text)"> ${escHtml(item.event_type)}${escHtml(detail)}</span>
+            <div class="feed-meta">${escHtml(item.project || '')} · ${escHtml(when)}</div>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  // ── Render verdicts ──
+  function renderVerdicts(feed) {
+    // We don't have a dedicated /api/verdicts endpoint; derive from feed where event_type indicates a verdict,
+    // or fetch /api/board which has aggregated data. For individual verdicts, use feed items of type 'verdict'.
+    // Show verdict-type feed events, falling back to empty state if none.
+    const verdictItems = feed.filter(f => {
+      const k = (f.event_type || '').toLowerCase();
+      return k.includes('verdict') || k.includes('judge') || k.includes('score');
+    });
+
+    const list = document.getElementById('verdict-list');
+    if (!verdictItems.length) {
+      list.innerHTML = '<div class="empty-state">No verdicts yet</div>';
+      return;
+    }
+    list.innerHTML = verdictItems.map(item => {
+      const role = (item.role || '').charAt(0).toUpperCase() + (item.role || '').slice(1);
+      const pts = item.payload && item.payload.points != null ? item.payload.points : null;
+      const reason = item.payload && item.payload.reason ? item.payload.reason : null;
+      const ptsClass = pts == null ? 'zero' : pts > 0 ? 'pos' : pts < 0 ? 'neg' : 'zero';
+      const ptsLabel = pts == null ? '?' : (pts >= 0 ? '+' + pts : pts) + ' pts';
+      return `
+        <div class="verdict-item">
+          <div class="verdict-header">
+            <span class="verdict-role">${escHtml(role)}</span>
+            <span class="verdict-pts ${ptsClass}">${ptsLabel}</span>
+          </div>
+          ${reason ? `<div class="verdict-reason">${escHtml(reason)}</div>` : ''}
+          <div class="feed-meta" style="margin-top:3px">${escHtml(timeAgo(item.created_at))}</div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  // ── Fetch all data ──
+  async function fetchAll() {
+    try {
+      const [boardRes, feedRes, statusRes] = await Promise.all([
+        fetch('/api/board'),
+        fetch('/api/feed'),
+        fetch('/api/status'),
+      ]);
+
+      if (!boardRes.ok || !feedRes.ok || !statusRes.ok) return;
+
+      const [board, feed, status] = await Promise.all([
+        boardRes.json(),
+        feedRes.json(),
+        statusRes.json(),
+      ]);
+
+      // Update agent status map
+      agentStatus = {};
+      for (const entry of status) {
+        agentStatus[(entry.role || '').toLowerCase()] = entry;
+      }
+
+      renderBoard(board);
+      renderAgents();
+      renderFeed(feed);
+      renderVerdicts(feed);
+
+      document.getElementById('last-update').textContent = 'Updated ' + timeAgo(new Date().toISOString());
+    } catch (e) {
+      console.error('Fetch error:', e);
+    }
+  }
+
+  // ── Tabs ──
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.board-panel').forEach(p => p.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById(btn.dataset.tab).classList.add('active');
+    });
+  });
+
+  // ── Utils ──
+  function escHtml(s) {
+    return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  // ── Init ──
+  fetchAll();
+  setInterval(fetchAll, 5000);
+</script>
+</body>
+</html>

--- a/test_server.py
+++ b/test_server.py
@@ -81,3 +81,38 @@ def test_board_cumulative_scores():
     entry = next(r for r in data if r["project"] == "proj-d" and r["role"] == "planner")
     assert entry["total_points"] == 15
     assert entry["verdict_count"] == 2
+
+
+# ── Fixture-based tests for dashboard and /api/verdicts ──
+
+@pytest.fixture()
+def isolated_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "DB_PATH", str(tmp_path / "test.db"))
+    with TestClient(server.app) as c:
+        yield c
+
+
+def test_get_root_returns_dashboard_html(isolated_client):
+    response = isolated_client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Bounty Monitor" in response.text
+
+
+def test_api_verdicts_empty(isolated_client):
+    response = isolated_client.get("/api/verdicts")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_api_verdicts_after_post(isolated_client):
+    isolated_client.post("/api/verdict", json={
+        "project": "test", "role": "builder", "points": 10, "reason": "good work"
+    })
+    response = isolated_client.get("/api/verdicts")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["role"] == "builder"
+    assert data[0]["points"] == 10
+    assert data[0]["reason"] == "good work"


### PR DESCRIPTION
## Summary

- Adds `static/index.html`: single-page dark-theme dashboard built with vanilla HTML/JS/CSS (no build step)
- Agent cards for Planner, Builder, Reviewer, Tester, Reviser — each shows live status (idle/busy/rework), current task, and total bounty points
- Scrolling activity feed with emoji indicators derived from event type
- Bounty leaderboard tabs: By Role and By Model, aggregated from `/api/board`
- Judge verdicts panel extracted from feed events containing verdict/judge/score event types
- Auto-refreshes every 5s via `fetch` polling (`/api/board`, `/api/feed`, `/api/status`)
- Includes `server.py` (FastAPI + SQLite backend from #1) with `StaticFiles` mount to serve the dashboard at `/`

## Test plan

- [ ] Start server: `uvicorn server:app --host 127.0.0.1 --port 18792`
- [ ] Open http://localhost:18792 — dashboard loads with dark theme
- [ ] POST a few events to `/api/report` and verify agent cards update within 5s
- [ ] POST verdicts to `/api/verdict` and verify leaderboard updates
- [ ] Check feed scrolls with new events prepended

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)