### PR TITLE
[BNT-4] Add bounty_report helper and ASDLC handler integration

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# builder.sh — dev-handler.sh with bounty reporting.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/bounty.sh
+source "$SCRIPT_DIR/lib/bounty.sh"
+
+SLUG="${ASDLC_SLUG:-}"
+REF="${ASDLC_ISSUE_NUMBER:-}"
+
+bounty_report "builder" "$SLUG" "$REF" "working"
+
+_handler="$SCRIPT_DIR/dev-handler.sh"
+[ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/dev-handler.sh"
+
+if "$_handler" "$@"; then
+    bounty_report "builder" "$SLUG" "$REF" "done"
+else
+    _rc=$?
+    bounty_report "builder" "$SLUG" "$REF" "failed"
+    exit "$_rc"
+fi

--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# bounty_report — fire-and-forget POST to the bounty monitor; never blocks.
+#
+# Usage: bounty_report <handler> <slug> <ref> <status> [trigger_judge]
+#   handler       planner | builder | reviewer | tester | reviser | merger
+#   slug          project slug ($ASDLC_SLUG)
+#   ref           issue or PR number
+#   status        working | done | failed
+#   trigger_judge (optional) true to queue judge verdict on merge
+
+BOUNTY_MONITOR_URL="${BOUNTY_MONITOR_URL:-http://localhost:18792}"
+
+bounty_report() {
+    local handler="${1:-}" slug="${2:-}" ref="${3:-}" status="${4:-}" trigger="${5:-false}"
+    local ts
+    ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
+    local payload
+    payload="{\"handler\":\"${handler}\",\"slug\":\"${slug}\",\"ref\":\"${ref}\",\"status\":\"${status}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"}"
+    curl -sf \
+        --max-time 3 \
+        --connect-timeout 2 \
+        -X POST \
+        -H 'Content-Type: application/json' \
+        -d "${payload}" \
+        "${BOUNTY_MONITOR_URL}/api/report" \
+        >/dev/null 2>&1 &
+    disown "$!" 2>/dev/null || true
+}

--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 # bounty_report — fire-and-forget POST to the bounty monitor; never blocks.
 #
-# Usage: bounty_report <handler> <slug> <ref> <status> [trigger_judge]
-#   handler       planner | builder | reviewer | tester | reviser | merger
-#   slug          project slug ($ASDLC_SLUG)
+# Usage: bounty_report <role> <project> <ref> <event_type> [trigger_judge]
+#   role          planner | builder | reviewer | tester | reviser | merger
+#   project       project slug ($ASDLC_SLUG)
 #   ref           issue or PR number
-#   status        working | done | failed
+#   event_type    working | done | failed
 #   trigger_judge (optional) true to queue judge verdict on merge
 
 BOUNTY_MONITOR_URL="${BOUNTY_MONITOR_URL:-http://localhost:18792}"
 
 bounty_report() {
-    local handler="${1:-}" slug="${2:-}" ref="${3:-}" status="${4:-}" trigger="${5:-false}"
+    local role="${1:-}" project="${2:-}" ref="${3:-}" event_type="${4:-}" trigger="${5:-false}"
     local ts
     ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
     local payload
-    payload="{\"handler\":\"${handler}\",\"slug\":\"${slug}\",\"ref\":\"${ref}\",\"status\":\"${status}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"}"
+    payload="{\"role\":\"${role}\",\"project\":\"${project}\",\"ref\":\"${ref}\",\"event_type\":\"${event_type}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"}"
     curl -sf \
         --max-time 3 \
         --connect-timeout 2 \

--- a/merger.sh
+++ b/merger.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# merger.sh — merge-handler.sh with bounty reporting; triggers judge on merge.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/bounty.sh
+source "$SCRIPT_DIR/lib/bounty.sh"
+
+SLUG="${ASDLC_SLUG:-}"
+REF="${ASDLC_PR_NUMBER:-}"
+
+bounty_report "merger" "$SLUG" "$REF" "working"
+
+_handler="$SCRIPT_DIR/merge-handler.sh"
+[ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/merge-handler.sh"
+
+if "$_handler" "$@"; then
+    bounty_report "merger" "$SLUG" "$REF" "done" "true"
+else
+    _rc=$?
+    bounty_report "merger" "$SLUG" "$REF" "failed"
+    exit "$_rc"
+fi

--- a/planner.sh
+++ b/planner.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# planner.sh — po-handler.sh with bounty reporting.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/bounty.sh
+source "$SCRIPT_DIR/lib/bounty.sh"
+
+SLUG="${ASDLC_SLUG:-}"
+REF="${ASDLC_ISSUE_NUMBER:-}"
+
+bounty_report "planner" "$SLUG" "$REF" "working"
+
+_handler="$SCRIPT_DIR/po-handler.sh"
+[ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/po-handler.sh"
+
+if "$_handler" "$@"; then
+    bounty_report "planner" "$SLUG" "$REF" "done"
+else
+    _rc=$?
+    bounty_report "planner" "$SLUG" "$REF" "failed"
+    exit "$_rc"
+fi

--- a/reviewer.sh
+++ b/reviewer.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# reviewer.sh — review-handler.sh with bounty reporting.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/bounty.sh
+source "$SCRIPT_DIR/lib/bounty.sh"
+
+SLUG="${ASDLC_SLUG:-}"
+REF="${ASDLC_PR_NUMBER:-}"
+
+bounty_report "reviewer" "$SLUG" "$REF" "working"
+
+_handler="$SCRIPT_DIR/review-handler.sh"
+[ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/review-handler.sh"
+
+if "$_handler" "$@"; then
+    bounty_report "reviewer" "$SLUG" "$REF" "done"
+else
+    _rc=$?
+    bounty_report "reviewer" "$SLUG" "$REF" "failed"
+    exit "$_rc"
+fi

--- a/reviser.sh
+++ b/reviser.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# reviser.sh — dev-rework-handler.sh with bounty reporting.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/bounty.sh
+source "$SCRIPT_DIR/lib/bounty.sh"
+
+SLUG="${ASDLC_SLUG:-}"
+REF="${ASDLC_PR_NUMBER:-}"
+
+bounty_report "reviser" "$SLUG" "$REF" "working"
+
+_handler="$SCRIPT_DIR/dev-rework-handler.sh"
+[ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/dev-rework-handler.sh"
+
+if "$_handler" "$@"; then
+    bounty_report "reviser" "$SLUG" "$REF" "done"
+else
+    _rc=$?
+    bounty_report "reviser" "$SLUG" "$REF" "failed"
+    exit "$_rc"
+fi

--- a/tester.sh
+++ b/tester.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# tester.sh — qa-handler.sh with bounty reporting.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/bounty.sh
+source "$SCRIPT_DIR/lib/bounty.sh"
+
+SLUG="${ASDLC_SLUG:-}"
+REF="${ASDLC_PR_NUMBER:-}"
+
+bounty_report "tester" "$SLUG" "$REF" "working"
+
+_handler="$SCRIPT_DIR/qa-handler.sh"
+[ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/qa-handler.sh"
+
+if "$_handler" "$@"; then
+    bounty_report "tester" "$SLUG" "$REF" "done"
+else
+    _rc=$?
+    bounty_report "tester" "$SLUG" "$REF" "failed"
+    exit "$_rc"
+fi


### PR DESCRIPTION
Closes #4

## Changes

- **`lib/bounty.sh`** — defines `bounty_report()`: fire-and-forget curl POST to `/api/report`. Background process with 3s max-time and 2s connect-timeout; all errors suppressed; never blocks the pipeline if the monitor is down.
- **`planner.sh`** — wraps `po-handler.sh`; reports `working` at start, `done`/`failed` on exit.
- **`builder.sh`** — wraps `dev-handler.sh`; same pattern.
- **`reviewer.sh`** — wraps `review-handler.sh`; uses `ASDLC_PR_NUMBER` as ref.
- **`tester.sh`** — wraps `qa-handler.sh`; uses `ASDLC_PR_NUMBER` as ref.
- **`reviser.sh`** — wraps `dev-rework-handler.sh`; uses `ASDLC_PR_NUMBER` as ref.
- **`merger.sh`** — wraps `merge-handler.sh`; on successful merge sends `done` with `trigger_judge: true` to queue the judge agent.

## Deployment

Scripts are designed to be installed alongside the existing ASDLC handler scripts. When `po-handler.sh` (or equivalent) is present as a sibling, it is used directly. Otherwise `$ASDLC_ROOT/scripts/` is checked (error if neither). `lib/bounty.sh` should be installed to the target repo's `lib/` directory.

## Test Plan

- [ ] `bash -n` syntax check passes on all 7 files
- [ ] `shellcheck -S warning` passes with no warnings
- [ ] Fire-and-forget verified: `bounty_report` returns immediately even when monitor is unreachable
- [ ] JSON payload fields: `handler`, `slug`, `ref`, `status`, `trigger_judge`, `timestamp`
- [ ] `merger.sh` done payload includes `trigger_judge: true`
- [ ] Handler exit codes propagate correctly (failed path exits non-zero)