### PR TITLE
[BNT-9] Issue lifecycle history — track full pipeline journey per issue

### DIFF
--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -12,10 +12,18 @@ BOUNTY_MONITOR_URL="${BOUNTY_MONITOR_URL:-http://localhost:18792}"
 
 bounty_report() {
     local role="${1:-}" project="${2:-}" ref="${3:-}" event_type="${4:-}" trigger="${5:-false}"
+    local issue_number="${6:-}" pr_number="${7:-}"
     local ts
     ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
+    local issue_field="" pr_field=""
+    if [ -n "$issue_number" ]; then
+        issue_field=",\"issue_number\":${issue_number}"
+    fi
+    if [ -n "$pr_number" ]; then
+        pr_field=",\"pr_number\":${pr_number}"
+    fi
     local payload
-    payload="{\"role\":\"${role}\",\"project\":\"${project}\",\"ref\":\"${ref}\",\"event_type\":\"${event_type}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"}"
+    payload="{\"role\":\"${role}\",\"project\":\"${project}\",\"ref\":\"${ref}\",\"event_type\":\"${event_type}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"${issue_field}${pr_field}}"
     curl -sf \
         --max-time 3 \
         --connect-timeout 2 \

--- a/server.py
+++ b/server.py
@@ -49,6 +49,35 @@ def init_db():
             verdict_count INTEGER NOT NULL DEFAULT 0,
             updated_at TEXT NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS issue_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project TEXT NOT NULL,
+            issue_number INTEGER NOT NULL,
+            pr_number INTEGER,
+            role TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            agent TEXT,
+            model TEXT,
+            duration_seconds INTEGER,
+            rework_count INTEGER DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS pipeline_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project TEXT NOT NULL,
+            issue_number INTEGER NOT NULL,
+            pr_number INTEGER,
+            title TEXT,
+            outcome TEXT,
+            started_at TIMESTAMP,
+            completed_at TIMESTAMP,
+            total_duration_seconds INTEGER,
+            rework_count INTEGER DEFAULT 0,
+            total_bounty INTEGER DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
     """)
     conn.commit()
     conn.close()
@@ -69,6 +98,11 @@ class ReportPayload(BaseModel):
     model: Optional[str] = None
     event_type: str
     payload: Optional[Any] = None
+    issue_number: Optional[int] = None
+    pr_number: Optional[int] = None
+    agent: Optional[str] = None
+    duration_seconds: Optional[int] = None
+    rework_count: Optional[int] = None
 
 
 class VerdictPayload(BaseModel):
@@ -93,6 +127,54 @@ def _insert_event(data: ReportPayload):
             now,
         ),
     )
+
+    if data.issue_number is not None:
+        conn.execute(
+            """INSERT INTO issue_history
+               (project, issue_number, pr_number, role, event_type, agent, model,
+                duration_seconds, rework_count, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                data.project,
+                data.issue_number,
+                data.pr_number,
+                data.role,
+                data.event_type,
+                data.agent,
+                data.model,
+                data.duration_seconds,
+                data.rework_count or 0,
+                now,
+            ),
+        )
+
+        existing_run = conn.execute(
+            "SELECT id, rework_count FROM pipeline_runs WHERE project=? AND issue_number=?",
+            (data.project, data.issue_number),
+        ).fetchone()
+
+        if existing_run:
+            updates = ["completed_at=?"]
+            params: list = [now]
+            if data.pr_number is not None:
+                updates.append("pr_number=?")
+                params.append(data.pr_number)
+            if data.rework_count is not None:
+                updates.append("rework_count=rework_count+?")
+                params.append(data.rework_count)
+            params.append(existing_run["id"])
+            conn.execute(
+                f"UPDATE pipeline_runs SET {', '.join(updates)} WHERE id=?",
+                params,
+            )
+        else:
+            conn.execute(
+                """INSERT INTO pipeline_runs
+                   (project, issue_number, pr_number, started_at, completed_at, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (data.project, data.issue_number, data.pr_number, now, now, now),
+            )
+
     conn.commit()
     conn.close()
 
@@ -196,6 +278,66 @@ def get_verdicts():
     ).fetchall()
     conn.close()
     return [dict(r) for r in rows]
+
+
+@app.get("/api/history/{project}/{issue}")
+def get_history(project: str, issue: int):
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT id, project, issue_number, pr_number, role, event_type, agent, model,
+                  duration_seconds, rework_count, created_at
+           FROM issue_history
+           WHERE project=? AND issue_number=?
+           ORDER BY id ASC""",
+        (project, issue),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+@app.get("/api/runs")
+def get_runs():
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT id, project, issue_number, pr_number, title, outcome,
+                  started_at, completed_at, total_duration_seconds,
+                  rework_count, total_bounty, created_at
+           FROM pipeline_runs
+           ORDER BY id DESC"""
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+@app.get("/api/runs/{project}")
+def get_runs_by_project(project: str):
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT id, project, issue_number, pr_number, title, outcome,
+                  started_at, completed_at, total_duration_seconds,
+                  rework_count, total_bounty, created_at
+           FROM pipeline_runs
+           WHERE project=?
+           ORDER BY id DESC""",
+        (project,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+@app.get("/api/stats")
+def get_stats():
+    conn = get_db()
+    row = conn.execute(
+        """SELECT
+               COUNT(*) AS total_runs,
+               AVG(total_duration_seconds) AS avg_duration_seconds,
+               ROUND(100.0 * SUM(CASE WHEN outcome = 'clean' THEN 1 ELSE 0 END) / MAX(COUNT(*), 1), 2) AS success_rate,
+               ROUND(100.0 * SUM(CASE WHEN rework_count > 0 THEN 1 ELSE 0 END) / MAX(COUNT(*), 1), 2) AS rework_rate
+           FROM pipeline_runs"""
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else {}
 
 
 app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/test_server.py
+++ b/test_server.py
@@ -116,3 +116,101 @@ def test_api_verdicts_after_post(isolated_client):
     assert data[0]["role"] == "builder"
     assert data[0]["points"] == 10
     assert data[0]["reason"] == "good work"
+
+
+# ── issue_history and pipeline_runs tests ──
+
+def test_history_empty(isolated_client):
+    response = isolated_client.get("/api/history/proj-x/42")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_history_after_report_with_issue(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-h", role="builder", event_type="started",
+        issue_number=10, pr_number=5, model="claude-3"
+    ))
+    response = isolated_client.get("/api/history/proj-h/10")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["issue_number"] == 10
+    assert data[0]["pr_number"] == 5
+    assert data[0]["role"] == "builder"
+
+
+def test_history_no_entry_without_issue_number(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-h2", role="planner", event_type="working"
+    ))
+    response = isolated_client.get("/api/history/proj-h2/99")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_runs_empty(isolated_client):
+    response = isolated_client.get("/api/runs")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_runs_created_after_report(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-r", role="builder", event_type="started", issue_number=20
+    ))
+    response = isolated_client.get("/api/runs")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["issue_number"] == 20
+    assert data[0]["project"] == "proj-r"
+
+
+def test_runs_by_project(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-p1", role="builder", event_type="done", issue_number=1
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-p2", role="builder", event_type="done", issue_number=2
+    ))
+    response = isolated_client.get("/api/runs/proj-p1")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["project"] == "proj-p1"
+
+
+def test_stats_empty(isolated_client):
+    response = isolated_client.get("/api/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert "total_runs" in data
+    assert data["total_runs"] == 0
+
+
+def test_stats_with_runs(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-s", role="builder", event_type="done", issue_number=30
+    ))
+    response = isolated_client.get("/api/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_runs"] >= 1
+    assert "avg_duration_seconds" in data
+    assert "success_rate" in data
+    assert "rework_rate" in data
+
+
+def test_pipeline_run_not_duplicated(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-nd", role="planner", event_type="started", issue_number=50
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-nd", role="builder", event_type="done", issue_number=50, pr_number=99
+    ))
+    response = isolated_client.get("/api/runs/proj-nd")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["pr_number"] == 99


### PR DESCRIPTION
## Summary

- Adds `issue_history` table tracking every handler event with issue/PR linkage
- Adds `pipeline_runs` table tracking the full lifecycle per issue (one row per issue)
- Extends `ReportPayload` with `issue_number`, `pr_number`, `agent`, `duration_seconds`, `rework_count`
- Updates `bounty_report()` in `lib/bounty.sh` to accept and forward `issue_number` and `pr_number`
- New endpoints: `GET /api/history/{project}/{issue}`, `GET /api/runs`, `GET /api/runs/{project}`, `GET /api/stats`

## Test plan

- [x] All 18 tests pass (`python3 -m pytest test_server.py -v`)
- [x] `test_history_empty` — no entries before any reports
- [x] `test_history_after_report_with_issue` — issue_history row written when issue_number provided
- [x] `test_history_no_entry_without_issue_number` — no issue_history row when issue_number absent
- [x] `test_runs_created_after_report` — pipeline_runs row created on first event
- [x] `test_pipeline_run_not_duplicated` — second event updates existing run, does not create duplicate
- [x] `test_runs_by_project` — filtered correctly
- [x] `test_stats_with_runs` — returns total_runs, avg_duration_seconds, success_rate, rework_rate

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)