### PR TITLE
[BNT-13] Work queue feature end-to-end

### DIFF
--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -34,3 +34,25 @@ bounty_report() {
         >/dev/null 2>&1 &
     disown "$!" 2>/dev/null || true
 }
+
+# bounty_report_queue — fire-and-forget POST of a work-queue snapshot.
+#
+# Usage: bounty_report_queue <project> <items_json>
+#   project     project slug
+#   items_json  JSON array of queue items:
+#               [{"ref":"<ref>","status":"queued|in-flight|blocked",
+#                 "priority":<int>,"title":"<str>","url":"<str>"}]
+bounty_report_queue() {
+    local project="${1:-}" items_json="${2:-[]}"
+    local payload
+    payload="{\"project\":\"${project}\",\"items\":${items_json}}"
+    curl -sf \
+        --max-time 3 \
+        --connect-timeout 2 \
+        -X POST \
+        -H 'Content-Type: application/json' \
+        -d "${payload}" \
+        "${BOUNTY_MONITOR_URL}/api/queue" \
+        >/dev/null 2>&1 &
+    disown "$!" 2>/dev/null || true
+}

--- a/scanner.sh
+++ b/scanner.sh
@@ -50,9 +50,11 @@ scan_project() {
         2>/dev/null || echo "[]")
 
     # Build items JSON array via python3
-    local items_json
-    items_json=$(python3 - "$project" <<'PYEOF'
-import sys, json, os
+    # Write the script to a temp file so stdin is free for issues_json piped in.
+    local _py_tmp
+    _py_tmp=$(mktemp /tmp/scanner_XXXXXX.py)
+    cat > "$_py_tmp" <<'PYEOF'
+import sys, json
 
 project = sys.argv[1]
 raw = sys.stdin.read().strip()
@@ -93,7 +95,9 @@ for issue in issues:
 
 print(json.dumps(items))
 PYEOF
-<<< "$issues_json")
+    local items_json
+    items_json=$(echo "$issues_json" | python3 "$_py_tmp" "$project")
+    rm -f "$_py_tmp"
 
     # Post snapshot to bounty monitor (fire-and-forget)
     bounty_report_queue "$project" "$items_json"

--- a/scanner.sh
+++ b/scanner.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scanner.sh — scan a GitHub project for open issues/PRs and post a queue snapshot.
+#
+# Usage: scanner.sh [slug]
+#   slug   project slug (falls back to $ASDLC_SLUG)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/bounty.sh
+source "$SCRIPT_DIR/lib/bounty.sh"
+
+SLUG="${1:-${ASDLC_SLUG:-}}"
+
+# Map GitHub labels to queue statuses
+_label_to_status() {
+    local labels="$1"
+    if echo "$labels" | grep -qiE 'blocked|on-hold'; then
+        echo "blocked"
+    elif echo "$labels" | grep -qiE 'in-progress|in-flight|wip'; then
+        echo "in-flight"
+    else
+        echo "queued"
+    fi
+}
+
+# Map priority labels to integers (higher = more urgent)
+_label_to_priority() {
+    local labels="$1"
+    if echo "$labels" | grep -qi 'priority:high\|p0\|critical'; then
+        echo "3"
+    elif echo "$labels" | grep -qi 'priority:medium\|p1'; then
+        echo "2"
+    elif echo "$labels" | grep -qi 'priority:low\|p2'; then
+        echo "1"
+    else
+        echo "0"
+    fi
+}
+
+scan_project() {
+    local project="${1:-$SLUG}"
+    [ -n "$project" ] || { echo "scan_project: project slug required" >&2; return 1; }
+
+    # Fetch open issues (exclude PRs) as JSON
+    local issues_json
+    issues_json=$(gh issue list \
+        --state open \
+        --json number,title,url,labels \
+        --limit 100 \
+        2>/dev/null || echo "[]")
+
+    # Build items JSON array via python3
+    local items_json
+    items_json=$(python3 - "$project" <<'PYEOF'
+import sys, json, os
+
+project = sys.argv[1]
+raw = sys.stdin.read().strip()
+issues = json.loads(raw) if raw else []
+
+items = []
+for issue in issues:
+    number = str(issue.get("number", ""))
+    title  = issue.get("title", "")
+    url    = issue.get("url", "")
+    labels = " ".join(l.get("name", "") for l in issue.get("labels", []))
+
+    # status
+    if any(kw in labels.lower() for kw in ("blocked", "on-hold")):
+        status = "blocked"
+    elif any(kw in labels.lower() for kw in ("in-progress", "in-flight", "wip")):
+        status = "in-flight"
+    else:
+        status = "queued"
+
+    # priority
+    if any(kw in labels.lower() for kw in ("priority:high", "p0", "critical")):
+        priority = 3
+    elif any(kw in labels.lower() for kw in ("priority:medium", "p1")):
+        priority = 2
+    elif any(kw in labels.lower() for kw in ("priority:low", "p2")):
+        priority = 1
+    else:
+        priority = 0
+
+    items.append({
+        "ref":      number,
+        "status":   status,
+        "priority": priority,
+        "title":    title,
+        "url":      url,
+    })
+
+print(json.dumps(items))
+PYEOF
+<<< "$issues_json")
+
+    # Post snapshot to bounty monitor (fire-and-forget)
+    bounty_report_queue "$project" "$items_json"
+}
+
+# Run if invoked directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    scan_project "$SLUG"
+fi

--- a/server.py
+++ b/server.py
@@ -1,10 +1,10 @@
 import sqlite3
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from contextlib import asynccontextmanager
 from typing import Optional, Any
 
-from fastapi import FastAPI, BackgroundTasks
+from fastapi import FastAPI, BackgroundTasks, Query
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -78,6 +78,17 @@ def init_db():
             total_bounty INTEGER DEFAULT 0,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         );
+
+        CREATE TABLE IF NOT EXISTS work_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project TEXT NOT NULL,
+            ref TEXT NOT NULL,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            title TEXT,
+            url TEXT,
+            created_at TEXT NOT NULL
+        );
     """)
     conn.commit()
     conn.close()
@@ -111,6 +122,19 @@ class VerdictPayload(BaseModel):
     model: Optional[str] = None
     points: int
     reason: Optional[str] = None
+
+
+class QueueItem(BaseModel):
+    ref: str
+    status: str
+    priority: int = 0
+    title: Optional[str] = None
+    url: Optional[str] = None
+
+
+class QueueSnapshot(BaseModel):
+    project: str
+    items: list[QueueItem]
 
 
 def _insert_event(data: ReportPayload):
@@ -210,6 +234,23 @@ def _insert_verdict(data: VerdictPayload):
     conn.close()
 
 
+def _insert_queue_snapshot(data: QueueSnapshot):
+    conn = get_db()
+    now = datetime.now(timezone.utc).isoformat()
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+
+    # Purge entries older than 24h
+    conn.execute("DELETE FROM work_queue WHERE created_at < ?", (cutoff,))
+
+    for item in data.items:
+        conn.execute(
+            "INSERT INTO work_queue (project, ref, status, priority, title, url, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (data.project, item.ref, item.status, item.priority, item.title, item.url, now),
+        )
+    conn.commit()
+    conn.close()
+
+
 @app.post("/api/report", status_code=202)
 async def report(data: ReportPayload, background_tasks: BackgroundTasks):
     background_tasks.add_task(_insert_event, data)
@@ -220,6 +261,30 @@ async def report(data: ReportPayload, background_tasks: BackgroundTasks):
 async def verdict(data: VerdictPayload, background_tasks: BackgroundTasks):
     background_tasks.add_task(_insert_verdict, data)
     return {"status": "accepted"}
+
+
+@app.post("/api/queue", status_code=202)
+async def queue_snapshot(data: QueueSnapshot, background_tasks: BackgroundTasks):
+    background_tasks.add_task(_insert_queue_snapshot, data)
+    return {"status": "accepted"}
+
+
+@app.get("/api/queue")
+def get_queue(project: Optional[str] = Query(default=None)):
+    conn = get_db()
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+    if project:
+        rows = conn.execute(
+            "SELECT id, project, ref, status, priority, title, url, created_at FROM work_queue WHERE created_at >= ? AND project = ? ORDER BY priority DESC, created_at ASC",
+            (cutoff, project),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT id, project, ref, status, priority, title, url, created_at FROM work_queue WHERE created_at >= ? ORDER BY priority DESC, created_at ASC",
+            (cutoff,),
+        ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
 
 
 @app.get("/api/board")

--- a/server.py
+++ b/server.py
@@ -87,6 +87,7 @@ def init_db():
             priority INTEGER NOT NULL DEFAULT 0,
             title TEXT,
             url TEXT,
+            assigned_role TEXT,
             created_at TEXT NOT NULL
         );
     """)
@@ -130,6 +131,7 @@ class QueueItem(BaseModel):
     priority: int = 0
     title: Optional[str] = None
     url: Optional[str] = None
+    assigned_role: Optional[str] = None
 
 
 class QueueSnapshot(BaseModel):
@@ -244,8 +246,8 @@ def _insert_queue_snapshot(data: QueueSnapshot):
 
     for item in data.items:
         conn.execute(
-            "INSERT INTO work_queue (project, ref, status, priority, title, url, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (data.project, item.ref, item.status, item.priority, item.title, item.url, now),
+            "INSERT INTO work_queue (project, ref, status, priority, title, url, assigned_role, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (data.project, item.ref, item.status, item.priority, item.title, item.url, item.assigned_role, now),
         )
     conn.commit()
     conn.close()
@@ -275,12 +277,12 @@ def get_queue(project: Optional[str] = Query(default=None)):
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
     if project:
         rows = conn.execute(
-            "SELECT id, project, ref, status, priority, title, url, created_at FROM work_queue WHERE created_at >= ? AND project = ? ORDER BY priority DESC, created_at ASC",
+            "SELECT id, project, ref, status, priority, title, url, assigned_role, created_at FROM work_queue WHERE created_at >= ? AND project = ? ORDER BY priority DESC, created_at ASC",
             (cutoff, project),
         ).fetchall()
     else:
         rows = conn.execute(
-            "SELECT id, project, ref, status, priority, title, url, created_at FROM work_queue WHERE created_at >= ? ORDER BY priority DESC, created_at ASC",
+            "SELECT id, project, ref, status, priority, title, url, assigned_role, created_at FROM work_queue WHERE created_at >= ? ORDER BY priority DESC, created_at ASC",
             (cutoff,),
         ).fetchall()
     conn.close()

--- a/static/index.html
+++ b/static/index.html
@@ -783,15 +783,16 @@
       const wait = timeAgo(item.created_at);
       const refDisplay = item.ref ? `#${item.ref}` : '—';
       const titleHtml = item.title ? `<div class="queue-item-title">${escHtml(item.title)}</div>` : '';
-      const refHtml = item.url
+      const refHtml = item.url && item.url.startsWith('http')
         ? `<a href="${escHtml(item.url)}" target="_blank" rel="noopener">${escHtml(refDisplay)}</a>`
         : escHtml(refDisplay);
+      const roleHtml = item.assigned_role ? `<span style="color:var(--accent);font-weight:600"> · ${escHtml(item.assigned_role)}</span>` : '';
       return `
         <div class="queue-item">
           <div class="queue-item-left">
             <div class="queue-item-ref">${refHtml}</div>
             ${titleHtml}
-            <div class="queue-item-meta">${escHtml(item.project || '')}</div>
+            <div class="queue-item-meta">${escHtml(item.project || '')}${roleHtml}</div>
           </div>
           <div class="queue-item-right">
             <span class="priority-badge ${pr.cls}">${pr.text}</span>

--- a/static/index.html
+++ b/static/index.html
@@ -22,6 +22,9 @@
       --idle: #6b7590;
       --busy: #6366f1;
       --rework: #f59e0b;
+      --in-flight: #6366f1;
+      --queued: #22d3ee;
+      --blocked: #f87171;
     }
 
     body {
@@ -325,6 +328,162 @@
       padding: 16px;
     }
 
+    /* ── Queue section ── */
+    #queue-section {
+      grid-column: 1 / -1;
+      grid-row: 3;
+    }
+
+    .queue-controls {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 12px;
+      flex-wrap: wrap;
+    }
+
+    .queue-filter-label {
+      font-size: 0.7rem;
+      color: var(--muted);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    #queue-project-filter {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 0.75rem;
+      padding: 4px 8px;
+      outline: none;
+      cursor: pointer;
+    }
+
+    #queue-project-filter:focus {
+      border-color: var(--accent);
+    }
+
+    .queue-groups {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 16px;
+    }
+
+    .queue-group {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      overflow: hidden;
+    }
+
+    .queue-group-header {
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .queue-group-title {
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .queue-group-title.in-flight { color: var(--in-flight); }
+    .queue-group-title.queued    { color: var(--queued); }
+    .queue-group-title.blocked   { color: var(--blocked); }
+
+    .queue-count {
+      font-size: 0.68rem;
+      font-weight: 700;
+      background: var(--surface2);
+      color: var(--muted);
+      padding: 2px 7px;
+      border-radius: 10px;
+    }
+
+    .queue-items {
+      max-height: 280px;
+      overflow-y: auto;
+    }
+
+    .queue-items::-webkit-scrollbar { width: 4px; }
+    .queue-items::-webkit-scrollbar-track { background: transparent; }
+    .queue-items::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    .queue-item {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 9px 14px;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.77rem;
+    }
+
+    .queue-item:last-child { border-bottom: none; }
+
+    .queue-item-left { flex: 1; min-width: 0; }
+
+    .queue-item-ref {
+      font-weight: 600;
+      color: var(--accent2);
+      font-size: 0.72rem;
+      margin-bottom: 2px;
+    }
+
+    .queue-item-ref a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .queue-item-ref a:hover { text-decoration: underline; }
+
+    .queue-item-title {
+      color: var(--text);
+      font-size: 0.75rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .queue-item-meta {
+      color: var(--muted);
+      font-size: 0.68rem;
+      margin-top: 2px;
+    }
+
+    .queue-item-right {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 4px;
+      flex-shrink: 0;
+    }
+
+    .priority-badge {
+      font-size: 0.6rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+
+    .priority-badge.p3 { background: #3b1a1a; color: var(--red); }
+    .priority-badge.p2 { background: #2d2310; color: var(--yellow); }
+    .priority-badge.p1 { background: #1a2230; color: var(--accent2); }
+    .priority-badge.p0 { background: var(--surface2); color: var(--muted); }
+
+    .wait-time {
+      font-size: 0.65rem;
+      color: var(--muted);
+    }
+
     @media (max-width: 900px) {
       main {
         grid-template-columns: 1fr;
@@ -332,6 +491,8 @@
       }
       #board-section { grid-column: 1; grid-row: 3; }
       #bottom-section { grid-column: 1; grid-row: 2; grid-template-columns: 1fr; }
+      #queue-section { grid-column: 1; grid-row: 4; }
+      .queue-groups { grid-template-columns: 1fr; }
     }
   </style>
 </head>
@@ -386,6 +547,40 @@
       <div class="scroll-inner" id="verdict-list"></div>
     </div>
   </div>
+
+  <!-- Work Queue -->
+  <section id="queue-section">
+    <div class="section-title">Work Queue</div>
+    <div class="queue-controls">
+      <span class="queue-filter-label">Project</span>
+      <select id="queue-project-filter">
+        <option value="">All projects</option>
+      </select>
+    </div>
+    <div class="queue-groups">
+      <div class="queue-group" id="queue-group-in-flight">
+        <div class="queue-group-header">
+          <span class="queue-group-title in-flight">In Flight</span>
+          <span class="queue-count" id="queue-count-in-flight">0</span>
+        </div>
+        <div class="queue-items" id="queue-items-in-flight"></div>
+      </div>
+      <div class="queue-group" id="queue-group-queued">
+        <div class="queue-group-header">
+          <span class="queue-group-title queued">Queued</span>
+          <span class="queue-count" id="queue-count-queued">0</span>
+        </div>
+        <div class="queue-items" id="queue-items-queued"></div>
+      </div>
+      <div class="queue-group" id="queue-group-blocked">
+        <div class="queue-group-header">
+          <span class="queue-group-title blocked">Blocked</span>
+          <span class="queue-count" id="queue-count-blocked">0</span>
+        </div>
+        <div class="queue-items" id="queue-items-blocked"></div>
+      </div>
+    </div>
+  </section>
 </main>
 
 <script>
@@ -564,23 +759,114 @@
     }).join('');
   }
 
+  // ── Queue state ──
+  let queueProjects = new Set();
+  let selectedQueueProject = '';
+
+  function priorityLabel(p) {
+    if (p >= 3) return { cls: 'p3', text: 'High' };
+    if (p === 2) return { cls: 'p2', text: 'Med' };
+    if (p === 1) return { cls: 'p1', text: 'Low' };
+    return { cls: 'p0', text: '—' };
+  }
+
+  function renderQueueGroup(containerId, countId, items) {
+    const container = document.getElementById(containerId);
+    const countEl = document.getElementById(countId);
+    countEl.textContent = items.length;
+    if (!items.length) {
+      container.innerHTML = '<div class="empty-state">Nothing here</div>';
+      return;
+    }
+    container.innerHTML = items.map(item => {
+      const pr = priorityLabel(item.priority || 0);
+      const wait = timeAgo(item.created_at);
+      const refDisplay = item.ref ? `#${item.ref}` : '—';
+      const titleHtml = item.title ? `<div class="queue-item-title">${escHtml(item.title)}</div>` : '';
+      const refHtml = item.url
+        ? `<a href="${escHtml(item.url)}" target="_blank" rel="noopener">${escHtml(refDisplay)}</a>`
+        : escHtml(refDisplay);
+      return `
+        <div class="queue-item">
+          <div class="queue-item-left">
+            <div class="queue-item-ref">${refHtml}</div>
+            ${titleHtml}
+            <div class="queue-item-meta">${escHtml(item.project || '')}</div>
+          </div>
+          <div class="queue-item-right">
+            <span class="priority-badge ${pr.cls}">${pr.text}</span>
+            <span class="wait-time">${escHtml(wait)}</span>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  function renderQueue(items) {
+    // Update project filter options
+    const newProjects = new Set(items.map(i => i.project).filter(Boolean));
+    let filterChanged = false;
+    for (const p of newProjects) {
+      if (!queueProjects.has(p)) { queueProjects.add(p); filterChanged = true; }
+    }
+    if (filterChanged) {
+      const sel = document.getElementById('queue-project-filter');
+      const current = sel.value;
+      sel.innerHTML = '<option value="">All projects</option>' +
+        [...queueProjects].sort().map(p => `<option value="${escHtml(p)}"${p === current ? ' selected' : ''}>${escHtml(p)}</option>`).join('');
+    }
+
+    // Filter by selected project
+    const filtered = selectedQueueProject
+      ? items.filter(i => i.project === selectedQueueProject)
+      : items;
+
+    const byStatus = { 'in-flight': [], queued: [], blocked: [] };
+    for (const item of filtered) {
+      const s = (item.status || 'queued').toLowerCase();
+      if (byStatus[s]) byStatus[s].push(item);
+      else byStatus['queued'].push(item);
+    }
+
+    // Sort each group by priority desc then wait time asc
+    for (const g of Object.values(byStatus)) {
+      g.sort((a, b) => (b.priority || 0) - (a.priority || 0) || new Date(a.created_at) - new Date(b.created_at));
+    }
+
+    renderQueueGroup('queue-items-in-flight', 'queue-count-in-flight', byStatus['in-flight']);
+    renderQueueGroup('queue-items-queued',    'queue-count-queued',    byStatus['queued']);
+    renderQueueGroup('queue-items-blocked',   'queue-count-blocked',   byStatus['blocked']);
+  }
+
+  document.getElementById('queue-project-filter').addEventListener('change', function() {
+    selectedQueueProject = this.value;
+    // Re-fetch to apply filter
+    fetchAll();
+  });
+
   // ── Fetch all data ──
   async function fetchAll() {
     try {
-      const [boardRes, feedRes, statusRes, verdictsRes] = await Promise.all([
+      const queueUrl = selectedQueueProject
+        ? `/api/queue?project=${encodeURIComponent(selectedQueueProject)}`
+        : '/api/queue';
+
+      const [boardRes, feedRes, statusRes, verdictsRes, queueRes] = await Promise.all([
         fetch('/api/board'),
         fetch('/api/feed'),
         fetch('/api/status'),
         fetch('/api/verdicts'),
+        fetch(queueUrl),
       ]);
 
-      if (!boardRes.ok || !feedRes.ok || !statusRes.ok || !verdictsRes.ok) return;
+      if (!boardRes.ok || !feedRes.ok || !statusRes.ok || !verdictsRes.ok || !queueRes.ok) return;
 
-      const [board, feed, status, verdicts] = await Promise.all([
+      const [board, feed, status, verdicts, queue] = await Promise.all([
         boardRes.json(),
         feedRes.json(),
         statusRes.json(),
         verdictsRes.json(),
+        queueRes.json(),
       ]);
 
       // Update agent status map
@@ -593,6 +879,7 @@
       renderAgents();
       renderFeed(feed);
       renderVerdicts(verdicts);
+      renderQueue(queue);
 
       document.getElementById('last-update').textContent = 'Updated ' + timeAgo(new Date().toISOString());
     } catch (e) {

--- a/test_server.py
+++ b/test_server.py
@@ -214,3 +214,70 @@ def test_pipeline_run_not_duplicated(isolated_client):
     data = response.json()
     assert len(data) == 1
     assert data[0]["pr_number"] == 99
+
+
+# ── Queue endpoint tests ──
+
+def test_queue_empty(isolated_client):
+    response = isolated_client.get("/api/queue")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_queue_post_accepted(isolated_client):
+    resp = isolated_client.post("/api/queue", json={
+        "project": "proj-q",
+        "items": [
+            {"ref": "42", "status": "queued", "priority": 1, "title": "Fix bug", "url": "https://example.com/42"},
+        ],
+    })
+    assert resp.status_code == 202
+    assert resp.json() == {"status": "accepted"}
+
+
+def test_queue_returns_items(isolated_client):
+    server._insert_queue_snapshot(server.QueueSnapshot(
+        project="proj-q",
+        items=[
+            server.QueueItem(ref="10", status="in-flight", priority=2, title="Feature A", url="https://example.com/10"),
+            server.QueueItem(ref="11", status="queued", priority=0, title="Feature B"),
+            server.QueueItem(ref="12", status="blocked", priority=3),
+        ],
+    ))
+    resp = isolated_client.get("/api/queue")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+    statuses = {item["ref"]: item["status"] for item in data}
+    assert statuses["10"] == "in-flight"
+    assert statuses["11"] == "queued"
+    assert statuses["12"] == "blocked"
+
+
+def test_queue_project_filter(isolated_client):
+    server._insert_queue_snapshot(server.QueueSnapshot(
+        project="alpha",
+        items=[server.QueueItem(ref="1", status="queued", priority=0)],
+    ))
+    server._insert_queue_snapshot(server.QueueSnapshot(
+        project="beta",
+        items=[server.QueueItem(ref="2", status="queued", priority=0)],
+    ))
+    resp = isolated_client.get("/api/queue?project=alpha")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(item["project"] == "alpha" for item in data)
+    assert any(item["ref"] == "1" for item in data)
+
+
+def test_queue_priority_field(isolated_client):
+    server._insert_queue_snapshot(server.QueueSnapshot(
+        project="proj-p",
+        items=[server.QueueItem(ref="99", status="queued", priority=3, title="Critical")],
+    ))
+    resp = isolated_client.get("/api/queue")
+    assert resp.status_code == 200
+    data = resp.json()
+    item = next(i for i in data if i["ref"] == "99")
+    assert item["priority"] == 3
+    assert item["title"] == "Critical"

--- a/test_server.py
+++ b/test_server.py
@@ -281,3 +281,20 @@ def test_queue_priority_field(isolated_client):
     item = next(i for i in data if i["ref"] == "99")
     assert item["priority"] == 3
     assert item["title"] == "Critical"
+
+
+def test_queue_assigned_role_field(isolated_client):
+    server._insert_queue_snapshot(server.QueueSnapshot(
+        project="proj-r",
+        items=[
+            server.QueueItem(ref="20", status="in-flight", priority=1, title="In progress", assigned_role="builder"),
+            server.QueueItem(ref="21", status="queued", priority=0, title="Pending"),
+        ],
+    ))
+    resp = isolated_client.get("/api/queue")
+    assert resp.status_code == 200
+    data = resp.json()
+    in_flight = next(i for i in data if i["ref"] == "20")
+    queued = next(i for i in data if i["ref"] == "21")
+    assert in_flight["assigned_role"] == "builder"
+    assert queued["assigned_role"] is None


### PR DESCRIPTION
## Summary

- Adds `work_queue` SQLite table with 24-hour retention and auto-purge on insert
- New `POST /api/queue` and `GET /api/queue` endpoints (with `?project=` filter)
- `bounty_report_queue()` fire-and-forget helper in `lib/bounty.sh`
- `scanner.sh` with `scan_project()` that reads open GitHub issues and posts a queue snapshot
- Queue tab in dashboard showing **In Flight / Queued / Blocked** columns, priority badges, waiting time, and click-through links to GitHub

Closes #13

## Test plan

- [x] All 14 tests pass (`python3 -m pytest test_server.py -v`)
- [x] `test_queue_empty` — GET /api/queue returns `[]` on fresh DB
- [x] `test_queue_post_accepted` — POST /api/queue returns 202
- [x] `test_queue_returns_items` — items persisted with correct status fields
- [x] `test_queue_project_filter` — `?project=alpha` only returns alpha items
- [x] `test_queue_priority_field` — priority value and title round-trip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)