### PR TITLE
[BNT-12] Rich event context across handlers, server, dashboard

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -6,18 +6,30 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/bounty.sh
 source "$SCRIPT_DIR/lib/bounty.sh"
 
-SLUG="${ASDLC_SLUG:-}"
-REF="${ASDLC_ISSUE_NUMBER:-}"
+_ISSUE="${ASDLC_ISSUE_NUMBER:-}"
+_START=$SECONDS
 
-bounty_report "builder" "$SLUG" "$REF" "working"
+bounty_report "$(_bounty_payload "builder" "working")" || true
 
 _handler="$SCRIPT_DIR/dev-handler.sh"
 [ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/dev-handler.sh"
 
 if "$_handler" "$@"; then
-    bounty_report "builder" "$SLUG" "$REF" "done"
+    _DUR=$(( SECONDS - _START ))
+    _PR="${ASDLC_PR_NUMBER:-}"
+    bounty_report "$(_bounty_payload "builder" "done" "$_DUR" "Implementation complete")" || true
+    if [[ -n "$_ISSUE" ]]; then
+        gh issue comment "$_ISSUE" \
+            --body "🔨 Builder: Implementation complete (${_DUR}s).${_PR:+ PR #${_PR} opened.}" \
+            2>/dev/null || true
+    fi
+    if [[ -n "$_PR" ]]; then
+        gh pr comment "$_PR" \
+            --body "🔨 Builder: Implementation complete (${_DUR}s). Opened from issue #${_ISSUE:-?}." \
+            2>/dev/null || true
+    fi
 else
     _rc=$?
-    bounty_report "builder" "$SLUG" "$REF" "failed"
+    bounty_report "$(_bounty_payload "builder" "failed" "$(( SECONDS - _START ))" "Handler failed")" || true
     exit "$_rc"
 fi

--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -1,29 +1,59 @@
 #!/usr/bin/env bash
 # bounty_report — fire-and-forget POST to the bounty monitor; never blocks.
 #
-# Usage: bounty_report <role> <project> <ref> <event_type> [trigger_judge]
-#   role          planner | builder | reviewer | tester | reviser | merger
-#   project       project slug ($ASDLC_SLUG)
-#   ref           issue or PR number
-#   event_type    working | done | failed
-#   trigger_judge (optional) true to queue judge verdict on merge
+# New API:    bounty_report <json_payload>
+# Legacy API: bounty_report <role> <project> <ref> <event_type> [trigger_judge]
+#
+# Helper: _bounty_payload <role> <event_type> [duration_seconds] [detail] [trigger_judge]
+#   Builds full JSON from env vars (ASDLC_SLUG, ASDLC_REPO, ASDLC_ISSUE_NUMBER,
+#   ASDLC_ISSUE_TITLE, ASDLC_ISSUE_URL, ASDLC_PR_NUMBER, ASDLC_PR_URL,
+#   ASDLC_AGENT, ASDLC_AGENT_MODEL, ASDLC_REWORK_COUNT) + explicit args.
 
 BOUNTY_MONITOR_URL="${BOUNTY_MONITOR_URL:-http://localhost:18792}"
 
-bounty_report() {
-    local role="${1:-}" project="${2:-}" ref="${3:-}" event_type="${4:-}" trigger="${5:-false}"
-    local issue_number="${6:-}" pr_number="${7:-}"
+_bounty_payload() {
+    local role="$1" event_type="$2" duration="${3:-}" detail="${4:-}" trigger="${5:-false}"
     local ts
     ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
-    local issue_field="" pr_field=""
-    if [ -n "$issue_number" ]; then
-        issue_field=",\"issue_number\":${issue_number}"
-    fi
-    if [ -n "$pr_number" ]; then
-        pr_field=",\"pr_number\":${pr_number}"
-    fi
+    _BP_ROLE="$role" _BP_EVENT="$event_type" _BP_DURATION="$duration" \
+    _BP_DETAIL="$detail" _BP_TRIGGER="$trigger" _BP_TS="$ts" \
+    python3 -c "
+import json, os
+def _int(v): return int(v) if v and str(v).strip().isdigit() else None
+def _bool(v): return str(v).lower() == 'true'
+print(json.dumps({
+    'role':             os.environ['_BP_ROLE'],
+    'project':          os.environ.get('ASDLC_SLUG') or None,
+    'slug':             os.environ.get('ASDLC_SLUG') or None,
+    'repo':             os.environ.get('ASDLC_REPO') or None,
+    'issue_number':     _int(os.environ.get('ASDLC_ISSUE_NUMBER', '')),
+    'issue_title':      os.environ.get('ASDLC_ISSUE_TITLE') or None,
+    'issue_url':        os.environ.get('ASDLC_ISSUE_URL') or None,
+    'pr_number':        _int(os.environ.get('ASDLC_PR_NUMBER', '')),
+    'pr_url':           os.environ.get('ASDLC_PR_URL') or None,
+    'agent':            os.environ.get('ASDLC_AGENT') or None,
+    'model':            os.environ.get('ASDLC_AGENT_MODEL') or os.environ.get('CLAUDE_MODEL') or None,
+    'event_type':       os.environ['_BP_EVENT'],
+    'duration_seconds': _int(os.environ.get('_BP_DURATION', '')),
+    'detail':           os.environ.get('_BP_DETAIL') or None,
+    'rework_count':     _int(os.environ.get('ASDLC_REWORK_COUNT', '')) or 0,
+    'trigger_judge':    _bool(os.environ['_BP_TRIGGER']),
+    'timestamp':        os.environ['_BP_TS'],
+}))
+" 2>/dev/null || printf '{"role":"%s","event_type":"%s","timestamp":"%s"}' "$role" "$event_type" "$ts"
+}
+
+bounty_report() {
     local payload
-    payload="{\"role\":\"${role}\",\"project\":\"${project}\",\"ref\":\"${ref}\",\"event_type\":\"${event_type}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"${issue_field}${pr_field}}"
+    if [[ "${1:-}" == "{"* ]]; then
+        payload="$1"
+    else
+        # Legacy positional: bounty_report <role> <project> <ref> <event_type> [trigger_judge]
+        local role="${1:-}" project="${2:-}" ref="${3:-}" event_type="${4:-}" trigger="${5:-false}"
+        local ts
+        ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
+        payload="{\"role\":\"${role}\",\"project\":\"${project}\",\"ref\":\"${ref}\",\"event_type\":\"${event_type}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"}"
+    fi
     curl -sf \
         --max-time 3 \
         --connect-timeout 2 \

--- a/merger.sh
+++ b/merger.sh
@@ -6,18 +6,25 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/bounty.sh
 source "$SCRIPT_DIR/lib/bounty.sh"
 
-SLUG="${ASDLC_SLUG:-}"
-REF="${ASDLC_PR_NUMBER:-}"
+_PR="${ASDLC_PR_NUMBER:-}"
+_ISSUE="${ASDLC_ISSUE_NUMBER:-}"
+_START=$SECONDS
 
-bounty_report "merger" "$SLUG" "$REF" "working"
+bounty_report "$(_bounty_payload "merger" "working")" || true
 
 _handler="$SCRIPT_DIR/merge-handler.sh"
 [ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/merge-handler.sh"
 
 if "$_handler" "$@"; then
-    bounty_report "merger" "$SLUG" "$REF" "done" "true"
+    _DUR=$(( SECONDS - _START ))
+    bounty_report "$(_bounty_payload "merger" "done" "$_DUR" "Merged" "true")" || true
+    if [[ -n "$_PR" ]]; then
+        gh pr comment "$_PR" \
+            --body "📦 Merger: Merged (${_DUR}s).${_ISSUE:+ Issue #${_ISSUE} closed.}" \
+            2>/dev/null || true
+    fi
 else
     _rc=$?
-    bounty_report "merger" "$SLUG" "$REF" "failed"
+    bounty_report "$(_bounty_payload "merger" "failed" "$(( SECONDS - _START ))" "Handler failed")" || true
     exit "$_rc"
 fi

--- a/planner.sh
+++ b/planner.sh
@@ -6,18 +6,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/bounty.sh
 source "$SCRIPT_DIR/lib/bounty.sh"
 
-SLUG="${ASDLC_SLUG:-}"
-REF="${ASDLC_ISSUE_NUMBER:-}"
+_ISSUE="${ASDLC_ISSUE_NUMBER:-}"
+_START=$SECONDS
 
-bounty_report "planner" "$SLUG" "$REF" "working"
+bounty_report "$(_bounty_payload "planner" "working")" || true
 
 _handler="$SCRIPT_DIR/po-handler.sh"
 [ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/po-handler.sh"
 
 if "$_handler" "$@"; then
-    bounty_report "planner" "$SLUG" "$REF" "done"
+    _DUR=$(( SECONDS - _START ))
+    bounty_report "$(_bounty_payload "planner" "done" "$_DUR" "Spec complete")" || true
+    if [[ -n "$_ISSUE" ]]; then
+        gh issue comment "$_ISSUE" \
+            --body "🎯 Planner: Spec complete (${_DUR}s). Issue #${_ISSUE} ready for implementation." \
+            2>/dev/null || true
+    fi
 else
     _rc=$?
-    bounty_report "planner" "$SLUG" "$REF" "failed"
+    bounty_report "$(_bounty_payload "planner" "failed" "$(( SECONDS - _START ))" "Handler failed")" || true
     exit "$_rc"
 fi

--- a/reviewer.sh
+++ b/reviewer.sh
@@ -6,18 +6,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/bounty.sh
 source "$SCRIPT_DIR/lib/bounty.sh"
 
-SLUG="${ASDLC_SLUG:-}"
-REF="${ASDLC_PR_NUMBER:-}"
+_PR="${ASDLC_PR_NUMBER:-}"
+_START=$SECONDS
 
-bounty_report "reviewer" "$SLUG" "$REF" "working"
+bounty_report "$(_bounty_payload "reviewer" "working")" || true
 
 _handler="$SCRIPT_DIR/review-handler.sh"
 [ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/review-handler.sh"
 
 if "$_handler" "$@"; then
-    bounty_report "reviewer" "$SLUG" "$REF" "done"
+    _DUR=$(( SECONDS - _START ))
+    bounty_report "$(_bounty_payload "reviewer" "done" "$_DUR" "Review complete")" || true
+    if [[ -n "$_PR" ]]; then
+        gh pr comment "$_PR" \
+            --body "👀 Reviewer: Review complete (${_DUR}s). See inline comments above." \
+            2>/dev/null || true
+    fi
 else
     _rc=$?
-    bounty_report "reviewer" "$SLUG" "$REF" "failed"
+    bounty_report "$(_bounty_payload "reviewer" "failed" "$(( SECONDS - _START ))" "Handler failed")" || true
     exit "$_rc"
 fi

--- a/reviser.sh
+++ b/reviser.sh
@@ -6,18 +6,25 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/bounty.sh
 source "$SCRIPT_DIR/lib/bounty.sh"
 
-SLUG="${ASDLC_SLUG:-}"
-REF="${ASDLC_PR_NUMBER:-}"
+_PR="${ASDLC_PR_NUMBER:-}"
+_START=$SECONDS
 
-bounty_report "reviser" "$SLUG" "$REF" "working"
+bounty_report "$(_bounty_payload "reviser" "working")" || true
 
 _handler="$SCRIPT_DIR/dev-rework-handler.sh"
 [ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/dev-rework-handler.sh"
 
 if "$_handler" "$@"; then
-    bounty_report "reviser" "$SLUG" "$REF" "done"
+    _DUR=$(( SECONDS - _START ))
+    _RC="${ASDLC_REWORK_COUNT:-}"
+    bounty_report "$(_bounty_payload "reviser" "done" "$_DUR" "Rework complete")" || true
+    if [[ -n "$_PR" ]]; then
+        gh pr comment "$_PR" \
+            --body "🔧 Reviser: Rework complete (${_DUR}s).${_RC:+ Cycle #${_RC}.} PR #${_PR} updated." \
+            2>/dev/null || true
+    fi
 else
     _rc=$?
-    bounty_report "reviser" "$SLUG" "$REF" "failed"
+    bounty_report "$(_bounty_payload "reviser" "failed" "$(( SECONDS - _START ))" "Handler failed")" || true
     exit "$_rc"
 fi

--- a/scripts/judge.sh
+++ b/scripts/judge.sh
@@ -224,7 +224,13 @@ if [ "$BOUNTY_POINTS" -gt 0 ] && [ "$OUTCOME" = "clean" ]; then
 **Bounty bonus:** 🏆 ${BOUNTY_POINTS} pts split evenly (+${BONUS_EACH} each role)"
 fi
 
-COMMENT_BODY="## Judge Verdict — \`${OUTCOME}\`
+TOTAL_POINTS=$(( SCORE_PLANNER + SCORE_BUILDER + SCORE_REVIEWER + SCORE_TESTER ))
+_fmt_total() { [ "$1" -gt 0 ] 2>/dev/null && echo "+$1" || echo "$1"; }
+DISPLAY_TOTAL=$(_fmt_total "$TOTAL_POINTS")
+
+COMMENT_BODY="🏆 Judge: ${DISPLAY_TOTAL} pts total · Outcome: \`${OUTCOME}\` · ${REWORK_COUNT} rework cycle(s) · CI: ${CI_STATUS}
+
+## Judge Verdict — \`${OUTCOME}\`
 
 ${VERDICT_TEXT}
 

--- a/server.py
+++ b/server.py
@@ -80,6 +80,25 @@ def init_db():
         );
     """)
     conn.commit()
+    # Migration: add rich context columns if they don't exist yet
+    new_columns = [
+        ("issue_number", "INTEGER"),
+        ("issue_title", "TEXT"),
+        ("pr_number", "INTEGER"),
+        ("issue_url", "TEXT"),
+        ("pr_url", "TEXT"),
+        ("repo", "TEXT"),
+        ("agent", "TEXT"),
+        ("duration_seconds", "INTEGER"),
+        ("detail", "TEXT"),
+        ("rework_count", "INTEGER DEFAULT 0"),
+    ]
+    for col_name, col_type in new_columns:
+        try:
+            conn.execute(f"ALTER TABLE events ADD COLUMN {col_name} {col_type}")
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass  # column already exists
     conn.close()
 
 
@@ -98,11 +117,21 @@ class ReportPayload(BaseModel):
     model: Optional[str] = None
     event_type: str
     payload: Optional[Any] = None
+    # Rich context fields
+    slug: Optional[str] = None
+    repo: Optional[str] = None
     issue_number: Optional[int] = None
+    issue_title: Optional[str] = None
+    issue_url: Optional[str] = None
     pr_number: Optional[int] = None
+    pr_url: Optional[str] = None
     agent: Optional[str] = None
     duration_seconds: Optional[int] = None
+    detail: Optional[str] = None
     rework_count: Optional[int] = None
+    trigger_judge: Optional[bool] = None
+    timestamp: Optional[str] = None
+    ref: Optional[str] = None  # legacy compat
 
 
 class VerdictPayload(BaseModel):
@@ -117,7 +146,11 @@ def _insert_event(data: ReportPayload):
     conn = get_db()
     now = datetime.now(timezone.utc).isoformat()
     conn.execute(
-        "INSERT INTO events (project, role, model, event_type, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        """INSERT INTO events (
+            project, role, model, event_type, payload, created_at,
+            issue_number, issue_title, pr_number, issue_url, pr_url,
+            repo, agent, duration_seconds, detail, rework_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             data.project,
             data.role,
@@ -125,6 +158,16 @@ def _insert_event(data: ReportPayload):
             data.event_type,
             json.dumps(data.payload) if data.payload else None,
             now,
+            data.issue_number,
+            data.issue_title,
+            data.pr_number,
+            data.issue_url,
+            data.pr_url,
+            data.repo,
+            data.agent,
+            data.duration_seconds,
+            data.detail,
+            data.rework_count,
         ),
     )
 
@@ -236,7 +279,10 @@ def board():
 def feed():
     conn = get_db()
     rows = conn.execute(
-        "SELECT id, project, role, model, event_type, payload, created_at FROM events ORDER BY id DESC LIMIT 50"
+        """SELECT id, project, role, model, event_type, payload, created_at,
+               issue_number, issue_title, pr_number, issue_url, pr_url,
+               repo, agent, duration_seconds, detail, rework_count
+           FROM events ORDER BY id DESC LIMIT 50"""
     ).fetchall()
     conn.close()
     result = []
@@ -251,9 +297,10 @@ def feed():
 @app.get("/api/status")
 def status():
     conn = get_db()
-    # Latest event per project+role
     rows = conn.execute("""
-        SELECT e.project, e.role, e.model, e.event_type, e.payload, e.created_at
+        SELECT e.project, e.role, e.model, e.event_type, e.payload, e.created_at,
+               e.issue_number, e.issue_title, e.pr_number, e.issue_url, e.pr_url,
+               e.repo, e.agent, e.duration_seconds, e.detail, e.rework_count
         FROM events e
         INNER JOIN (
             SELECT project, role, MAX(id) AS max_id FROM events GROUP BY project, role

--- a/static/index.html
+++ b/static/index.html
@@ -448,9 +448,14 @@
       const ev = agentStatus[key] || {};
       const status = ev.event_type ? statusFromEvent(ev.event_type) : 'idle';
       const points = agentScores[key] || 0;
-      const task = ev.event_type
-        ? `${eventEmoji(ev.event_type)} ${ev.event_type}${ev.payload && typeof ev.payload === 'object' && ev.payload.task ? ': ' + ev.payload.task : ''}`
+
+      const issueTitle = ev.issue_title || (ev.payload && typeof ev.payload === 'object' && ev.payload.task) || '';
+      const taskLabel = ev.event_type
+        ? `${eventEmoji(ev.event_type)} ${escHtml(ev.event_type)}${issueTitle ? ': ' + escHtml(issueTitle) : ''}`
         : 'No activity yet';
+      const issueRef = ev.issue_url && isSafeUrl(ev.issue_url)
+        ? ` <a href="${escAttr(ev.issue_url)}" target="_blank" style="color:var(--accent2);font-size:0.7rem">#${ev.issue_number}</a>`
+        : '';
 
       const card = document.createElement('div');
       card.className = `agent-card ${status}`;
@@ -459,7 +464,7 @@
           <span class="agent-role">${ROLE_EMOJI[key] || '🤖'} ${role}</span>
           <span class="status-badge ${status}">${status}</span>
         </div>
-        <div class="agent-task">${escHtml(task)}</div>
+        <div class="agent-task">${taskLabel}${issueRef}</div>
         <div class="agent-bounty">⭐ ${points} pts</div>
       `;
       grid.appendChild(card);
@@ -522,16 +527,23 @@
       const emoji = eventEmoji(item.event_type);
       const role = (item.role || '').charAt(0).toUpperCase() + (item.role || '').slice(1);
       const when = timeAgo(item.created_at);
-      const detail = item.payload && typeof item.payload === 'object' && item.payload.task
-        ? ` — ${item.payload.task}`
-        : '';
+      const detail = item.detail || (item.payload && typeof item.payload === 'object' && item.payload.task) || '';
+
+      const issueLink = item.issue_url && isSafeUrl(item.issue_url)
+        ? `<a href="${escAttr(item.issue_url)}" target="_blank" style="color:var(--accent2)">issue #${item.issue_number}</a>`
+        : (item.issue_number ? `issue #${item.issue_number}` : '');
+      const prLink = item.pr_url && isSafeUrl(item.pr_url)
+        ? `<a href="${escAttr(item.pr_url)}" target="_blank" style="color:var(--accent2)">PR #${item.pr_number}</a>`
+        : (item.pr_number ? `PR #${item.pr_number}` : '');
+      const refs = [issueLink, prLink].filter(Boolean).join(' · ');
+
       return `
         <div class="feed-item">
           <span class="feed-emoji">${emoji}</span>
           <div>
             <span class="feed-role">${escHtml(role)}</span>
-            <span style="color:var(--text)"> ${escHtml(item.event_type)}${escHtml(detail)}</span>
-            <div class="feed-meta">${escHtml(item.project || '')} · ${escHtml(when)}</div>
+            <span style="color:var(--text)"> ${escHtml(item.event_type)}${detail ? ' — ' + escHtml(detail) : ''}</span>
+            <div class="feed-meta">${escHtml(item.project || '')}${refs ? ' · ' + refs : ''} · ${escHtml(when)}</div>
           </div>
         </div>
       `;
@@ -613,6 +625,14 @@
   // ── Utils ──
   function escHtml(s) {
     return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  function escAttr(s) {
+    return String(s || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function isSafeUrl(s) {
+    return /^https?:\/\//i.test(String(s || ''));
   }
 
   // ── Init ──

--- a/tester.sh
+++ b/tester.sh
@@ -6,18 +6,29 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/bounty.sh
 source "$SCRIPT_DIR/lib/bounty.sh"
 
-SLUG="${ASDLC_SLUG:-}"
-REF="${ASDLC_PR_NUMBER:-}"
+_PR="${ASDLC_PR_NUMBER:-}"
+_START=$SECONDS
 
-bounty_report "tester" "$SLUG" "$REF" "working"
+bounty_report "$(_bounty_payload "tester" "working")" || true
 
 _handler="$SCRIPT_DIR/qa-handler.sh"
 [ -x "$_handler" ] || _handler="${ASDLC_ROOT:?ASDLC_ROOT is required}/scripts/qa-handler.sh"
 
 if "$_handler" "$@"; then
-    bounty_report "tester" "$SLUG" "$REF" "done"
+    _DUR=$(( SECONDS - _START ))
+    bounty_report "$(_bounty_payload "tester" "done" "$_DUR" "QA passed")" || true
+    if [[ -n "$_PR" ]]; then
+        gh pr comment "$_PR" \
+            --body "🧪 Tester: QA passed (${_DUR}s). No blocking issues found." \
+            2>/dev/null || true
+    fi
 else
     _rc=$?
-    bounty_report "tester" "$SLUG" "$REF" "failed"
+    bounty_report "$(_bounty_payload "tester" "failed" "$(( SECONDS - _START ))" "QA failed")" || true
+    if [[ -n "$_PR" ]]; then
+        gh pr comment "$_PR" \
+            --body "🧪 Tester: QA failed ($(( SECONDS - _START ))s). See errors above." \
+            2>/dev/null || true
+    fi
     exit "$_rc"
 fi


### PR DESCRIPTION
Closes #12

## Changes

- **lib/bounty.sh**: Added `_bounty_payload()` helper that builds full JSON from env vars (issue/PR number, title, URL, repo, agent, model, duration, detail, rework_count); `bounty_report()` now accepts JSON string (new API) or positional args (legacy backward-compat preserved)
- **Handlers (planner, builder, reviewer, tester, reviser, merger)**: Build full JSON payloads via `_bounty_payload()`; track duration via `$SECONDS`; post emoji-prefixed status comments on issue/PR at completion via `gh issue comment` / `gh pr comment`
- **scripts/judge.sh**: Prepends `🏆 Judge: +N pts total · Outcome: X · N rework cycle(s) · CI: Y` summary line to existing scorecard comment
- **server.py**: Migration adds 10 new columns (issue_number, issue_title, pr_number, issue_url, pr_url, repo, agent, duration_seconds, detail, rework_count) with idempotent `ALTER TABLE`; `ReportPayload` accepts all new optional fields; insert/select persist and return new columns
- **static/index.html**: Feed items show clickable issue/PR links (using `escAttr` for safe URL rendering) and `detail` text; status cards show `issue_title` with clickable `#N` issue link

## Test Plan

- [ ] `bash -n lib/bounty.sh` and all handlers pass
- [ ] `python3 -c "import ast; ast.parse(open('server.py').read())"` passes
- [ ] Start server: `uvicorn server:app`; POST to `/api/report` with full payload; verify `/api/feed` returns new fields
- [ ] POST legacy 5-arg payload (no JSON prefix) to `/api/report` and verify backward compat
- [ ] Open dashboard — verify feed shows clickable issue/PR links
- [ ] Existing `bounty.db` with old schema: restart server, verify migration adds columns without data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)